### PR TITLE
Update embedding.py

### DIFF
--- a/embeddings/embedding.py
+++ b/embeddings/embedding.py
@@ -137,7 +137,9 @@ class Embedding:
         c = self.db.cursor()
         binarized = [(word, array('f', emb).tobytes()) for word, emb in batch]
         try:
+            c.execute("BEGIN TRANSACTION;")
             c.executemany("insert into embeddings values (?, ?)", binarized)
+            c.execute("COMMIT;")
         except Exception as e:
             print('insert failed\n{}'.format([w for w, e in batch]))
             raise e


### PR DESCRIPTION
Small change, but this greatly reduces the amount of time it takes to load embeddings into a database.

I am creating a new class to load an Embedding file with a total of 13.8m embeddings. With the default implementation, this would have taken approx 13h. With these two lines, it was reduced to approx 1h45m.

Thanks for this great package!