### PR TITLE
Fix database path to be platform agnostic

### DIFF
--- a/embeddings/embedding.py
+++ b/embeddings/embedding.py
@@ -19,7 +19,12 @@ class Embedding:
             str: absolute path to the file, located in the ``$EMBEDDINGS_ROOT`` directory.
 
         """
-        root = environ.get('EMBEDDINGS_ROOT', path.join(environ['HOME'], '.embeddings'))
+        root = environ.get('EMBEDDINGS_ROOT') 
+        if not root:
+            root = environ.get('HOME') or environ.get('USERPROFILE')
+            if not root:
+                raise KeyError(f"Must set either EMBEDDINGS_ROOT or HOME as an environment variable to create embeddings database")
+            root = path.join(root, '.embeddings')
         return path.join(path.abspath(root), p)
 
     @staticmethod


### PR DESCRIPTION
`HOME` is required to be set even if `EMBEDDINGS_ROOT` is get because the key access is executed to compute the default return value while accessing `EMBEDDINGS_ROOT`. `HOME` is generally not set on Windows, (`USERPROFILE` is set instead) which leads to an error. 
With the proposed update, if `EMBEDDINGS_ROOT` is set, not other platform-specific environment variables are accessed. If `EMBEDDINGS_ROOT` is not set, then either `HOME` or `USERPROFILE` is used. If both are set, then `HOME` has priority. If none of these are set, we throw an informative error.